### PR TITLE
Replace unmaintained JWT lib with golang-jwt/jwt/v4

### DIFF
--- a/push_notification_test.go
+++ b/push_notification_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/push_notifications.go
+++ b/push_notifications.go
@@ -11,7 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
Replace unmaintained JWT lib with github.com/golang-jwt/jwt/v4 to mitigate CVE-2020-26160
See: https://github.com/golang-jwt/jwt/blob/main/MIGRATION_GUIDE.md